### PR TITLE
fix 404 error on scripts when store code in url is configured in Magento

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,6 +69,7 @@ module.exports = {
     },
     output: {
         path: outputFolder,
-        filename: 'js/react.bundle.js'
+        filename: 'js/react.bundle.js',
+        publicPath: '/'
     }
 };


### PR DESCRIPTION
When "use store code in url" is configured in Magento, all bundles will return a 404 response.
![image](https://user-images.githubusercontent.com/1506882/75521898-f7b08380-5a08-11ea-8451-8be17dd5ae1e.png)

Pointing the publicPath to the root path will fix this issue:
![image](https://user-images.githubusercontent.com/1506882/75522134-86bd9b80-5a09-11ea-83f9-d4b41c8db8f5.png)

